### PR TITLE
Fixed issue where CarouselButton didn't take hover color of the button into account when initializing, causing it to always be black

### DIFF
--- a/Unity UI Carousel/CarouselButton.cs
+++ b/Unity UI Carousel/CarouselButton.cs
@@ -39,9 +39,7 @@ namespace Christina.UI
 
         private void Start()
         {
-            Color alphaHoverColor = hoverColor;
-            alphaHoverColor.a = 0f;
-            buttonBackground.color = alphaHoverColor;
+            buttonBackground.color = Color.clear;
         }
 
         public void OnPointerEnter(PointerEventData eventData)
@@ -68,7 +66,7 @@ namespace Christina.UI
             {
                 time += Time.deltaTime;
                 float lerpValue = time / duration;
-                Color newColor = buttonBackground.color;
+                Color newColor = hoverColor;
                 newColor.a = Mathf.Lerp(startAlpha, targetAlpha, lerpValue);
                 buttonBackground.color = newColor;
                 yield return null;

--- a/Unity UI Carousel/CarouselButton.cs
+++ b/Unity UI Carousel/CarouselButton.cs
@@ -39,7 +39,9 @@ namespace Christina.UI
 
         private void Start()
         {
-            buttonBackground.color = Color.clear;
+            Color alphaHoverColor = hoverColor;
+            alphaHoverColor.a = 0f;
+            buttonBackground.color = alphaHoverColor;
         }
 
         public void OnPointerEnter(PointerEventData eventData)


### PR DESCRIPTION
Simple fix for a simple problem. The base color of the button would always be returned to a transparent black (Color.clear) by the Start event, after which the ChangeAlpha routine would stick to the black color.